### PR TITLE
Fix for potential false password validation

### DIFF
--- a/src/Justin.AspNetCore.LdapAuthentication/LdapAuthentication.cs
+++ b/src/Justin.AspNetCore.LdapAuthentication/LdapAuthentication.cs
@@ -63,7 +63,7 @@ namespace Justin.AspNetCore.LdapAuthentication
             try
             {
                 _connection.Bind(distinguishedName, password);
-                return true;
+                return _connection.Bound;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
When doing some testing with the Novel package, if you do a bind with an invalid dn and empty password, it will not throw an exception, but the Bound property will be false.  Since this is wrapped by the UserManager it will probably not be possible, but thought I'd pass along the fix.  -- Thanks.